### PR TITLE
Current User Theme can now be installed using install-system

### DIFF
--- a/pakitheme
+++ b/pakitheme
@@ -118,5 +118,9 @@ EOF
 done < <(flatpak list --runtime --columns=arch:f | sort -u)
 
 for bundle in "${bundles[@]}"; do
-  flatpak install -y --$install_target "$bundle"
+  if [ "$install_target" == "system" ]; then
+    sudo flatpak install -y --$install_target "$bundle"
+  else
+    flatpak install -y --$install_target "$bundle"
+  fi
 done


### PR DESCRIPTION
This makes it usable in combination with sites like gnome-looks.org . 
When you install a theme there with ocs-url it will be installed as a user-theme. 
Sometimes you want it to be applied flatpak applications which are installed as system.
But when executing the script with sudo, your Theme has not been found. 

This is a work-arround, and if there would be any better way to fix this, let me know :)