### PR TITLE
Rename flatpak package name in appdata xml

### DIFF
--- a/stylepak
+++ b/stylepak
@@ -101,8 +101,8 @@ cat >"$build_dir/files/share/appdata/$app_id.appdata.xml" <<EOF
 <component type="runtime">
   <id>$app_id</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>$name Gtk theme</name>
-  <summary>$name Gtk theme (generated via stylepak)</summary>
+  <name>$name $theme</name>
+  <summary>$name $theme (generated via stylepak)</summary>
 </component>
 EOF
 

--- a/stylepak
+++ b/stylepak
@@ -101,8 +101,8 @@ cat >"$build_dir/files/share/appdata/$app_id.appdata.xml" <<EOF
 <component type="runtime">
   <id>$app_id</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>$name $theme</name>
-  <summary>$name $theme (generated via stylepak)</summary>
+  <name>$theme GTK Theme</name>
+  <summary>$theme (generated via stylepak)</summary>
 </component>
 EOF
 


### PR DESCRIPTION
Changed appdata.xml `<name>..</name> `
From "gtk theme" to $theme variable. 
This is to make a easy use for environment and others commands for flatpak, and identify the theme package on the flatpak package list. 


