### PR TITLE
Add a dot to theme name check, it's harmless.

### DIFF
--- a/stylepak
+++ b/stylepak
@@ -56,7 +56,7 @@ done
 [[ -n "$theme" ]] || \
   theme=$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")
 
-echo "$theme" | grep -Eq '^[A-Za-z0-9_\-]+$' || \
+echo "$theme" | grep -Eq '^[A-Za-z0-9._\-]+$' || \
   die "Invalid theme name (may only contain letters, digits, '_', '-'): $theme"
 
 echo "Converting theme: $theme"


### PR DESCRIPTION
There are themes with dots in names. This change will allow to install those.