### PR TITLE
Add back "clear-cache" command

### DIFF
--- a/stylepak
+++ b/stylepak
@@ -41,6 +41,7 @@ for arg in "$@"; do
       case "$arg" in
         install-system) install_target=system ;;
         install-user) install_target=user ;;
+        clear-cache) rm -rf "$stylepak_cache"; exit ;;
         *) die "$usage" ;;
       esac
     elif [[ -z "$theme" ]]; then


### PR DESCRIPTION
I don't know if I'm missing something but the "clear-cache" command is referenced in the Readme.md but it didn't work for me. I looked through the commit history and it seems to have gotten lost is [this commit](https://github.com/refi64/stylepak/commit/e1ead8be2548723d16f1cf87be27555694f6b3f9) so I just added it back.